### PR TITLE
Building rust-g for Linux in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM i386/debian:buster-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gcc-multilib \
+    libssl-dev \
+    pkg-config \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl https://sh.rustup.rs -sSfo rustup-init.sh \
+    && chmod +x rustup-init.sh \
+    && ./rustup-init.sh -y
+
+COPY . /rust-g
+
+WORKDIR /rust-g
+
+RUN /root/.cargo/bin/cargo build --release --features dmi,file,hash,http,log,url

--- a/docker-build-rust-g
+++ b/docker-build-rust-g
@@ -1,0 +1,4 @@
+#!/bin/bash
+GIT_HASH="$(git log | head -1 | awk -e '{print $2}' | head -c 12)"
+docker build -t rust-g:${GIT_HASH} -f Dockerfile .
+docker image tag rust-g:${GIT_HASH} rust-g:latest


### PR DESCRIPTION
* Adds a `Dockerfile` that builds rust-g for Linux
* Adds a script to build and tag the Docker image
